### PR TITLE
Change to address the mobile view

### DIFF
--- a/src/pages/NewHomepageTravelPage/HeroImage/ComingSoon.js
+++ b/src/pages/NewHomepageTravelPage/HeroImage/ComingSoon.js
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
     },
     typographyone: {
         [theme.breakpoints.down("sm")]: {
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     typographytwo: {
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
         [theme.breakpoints.down("sm")]: {
             textDecoration: "none !important",
             display: "block !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
             borderBottom: "none !important",
         },
     },
@@ -87,7 +87,7 @@ const ComingSoon = () => {
                                
                             </Box>
                             <Box className={classes.boxtwo}>
-                                <Typography className={classes.typographytwo} variant="h5" style={{ display: "inline-block", whiteSpace: "pre-line" }}>
+                                <Typography className={classes.typographytwo} variant="h5" style={{ display: "inline-block", whiteSpace: "pre-line", textAlign: "justify" }}>
                                     We're working non-stop to bring you the mobile app that curates your dream travel experiences. We'll notify you as soon as it's available. In the meantime, plan your next big adventure with us here on our site. Keep an eye out for updates about the mobile app's release.
                                 </Typography>
                             </Box>

--- a/src/pages/NewHomepageTravelPage/HeroImage/HeroImage.css
+++ b/src/pages/NewHomepageTravelPage/HeroImage/HeroImage.css
@@ -18,16 +18,13 @@
   /* Place text in the middle of the image */
   .hero-text {
     text-align: center;
-    position: absolute;
     top: 30%;
     left: 27%;
     white-space: nowrap;
     max-height: 600px;
     margin-top: 60px;
-    transform: translate(-50%, -50%);
     color: #334147;
     font-size: larger;
-    
   }
   
   .typewritereffecttwo{

--- a/src/pages/NewHomepageTravelPage/HeroImage/HeroImage.js
+++ b/src/pages/NewHomepageTravelPage/HeroImage/HeroImage.js
@@ -21,6 +21,7 @@ import { makeStyles } from "@mui/styles";
 
 const useStyles = makeStyles((theme) => ({
     typography1: {
+        marginRight: "6px !important",
         [theme.breakpoints.down("sm")]: {
             fontSize: "20px !important",
             marginRight: "65px !important",
@@ -38,7 +39,6 @@ const useStyles = makeStyles((theme) => ({
     typography3: {
         [theme.breakpoints.down("sm")]: {
             fontSize: "14px !important",
-            marginRight: "18px !important",
         },
     },
     typography4: {
@@ -50,9 +50,9 @@ const useStyles = makeStyles((theme) => ({
         },
     },
     boxtwo: {
-        marginLeft: "350px !important",
         display: "flex",
         flexDirection: "row !important",
+        marginLeft: "140px",
         [theme.breakpoints.down("sm")]: {
             fontSize: "14px !important",
             display: "block !important",
@@ -61,9 +61,9 @@ const useStyles = makeStyles((theme) => ({
         alignItems: "baseline",
     },
     boxthree: {
-        marginLeft: "350px !important",
         display: "flex",
         flexDirection: "row !important",
+        marginLeft: "140px",
         [theme.breakpoints.down("sm")]: {
             fontSize: "14px !important",
             display: "block !important",
@@ -80,13 +80,20 @@ const HeroImage = () => {
                 <div className="hero-text" >
                     {/* <TypewriterEffectOne /> */}
 
-                    <Box className={classes.boxtwo}>   <Typography className={classes.typography1} variant="h3">{'Travel Planning, '}</Typography><p>&nbsp;</p><Typography className={classes.typography2} variant="h3" marginBottom={3} display="inline-block" color="#1CCC6F" >{' Reinvented'}</Typography></Box>
+                    <Box className={classes.boxtwo}>
+                        <Typography className={classes.typography1} variant="h3">
+                            Travel Planning,
+                        </Typography>
+                        <Typography className={classes.typography2} variant="h3" marginBottom={3} display="inline-block" color="#1CCC6F" >
+                            Reinvented
+                        </Typography>
+                    </Box>
                     {/* <div className="typewritereffecttwo"> */}
                     {/* <TypewriterEffectTwo /> */}
 
                     <Box className={classes.boxthree}>
                         <Typography className={classes.typography3} variant="h5" >
-                            {'Get the most of your travel by leaving the planning to us'}
+                            Get the most of your travel by leaving the planning to us
                         </Typography>
                         {/* <p>&nbsp;</p>
                         <Typography variant="h5" className={classes.typography4}>
@@ -96,10 +103,7 @@ const HeroImage = () => {
 
                     <NewBookingForm />
                 </div>
-
             </div>
-
-            <ComingSoon />
         </div>
     );
 }

--- a/src/pages/NewHomepageTravelPage/HeroImage/NewBookingForm.js
+++ b/src/pages/NewHomepageTravelPage/HeroImage/NewBookingForm.js
@@ -44,15 +44,12 @@ const useStyles = makeStyles((theme) => ({
         backgroundColor: '#1CCC6F10',
         backdropFilter: 'blur(2px)',
         borderRadius: 10,
-        marginLeft: 300,
         marginTop: 50,
         width: 900,
         [theme.breakpoints.down("sm")]: {
             width: 350,
             borderRadius: 5,
-            marginLeft: 123,
             marginTop: 25,
-
         },
     },
     buttonletsplan: {

--- a/src/pages/NewHomepageTravelPage/HeroImage/NewSubsequentBookingContent.js
+++ b/src/pages/NewHomepageTravelPage/HeroImage/NewSubsequentBookingContent.js
@@ -159,6 +159,7 @@ const NewSubsequentBookingContent = ({ values, handleInputChange }) => {
                     id="booking-budget-input"
                     variant="filled"
                     name="budget"
+                    required
                     value={values.budget}
                     onChange={(evt) => handleInputChange('budget', evt.target.value)}
                     InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}

--- a/src/pages/NewHomepageTravelPage/NewHomePage.js
+++ b/src/pages/NewHomepageTravelPage/NewHomePage.js
@@ -2,10 +2,10 @@ import React from "react";
 import HeroImage from "./HeroImage/HeroImage";
 import { makeStyles } from "@mui/styles";
 import NewAppBar from "./NewAppBar";
-import NewBookingForm from "./HeroImage/NewBookingForm";
 import withRoot from "../../modules/withRoot";
 import AppFooter from "../../modules/views/AppFooter";
 import OtherPageContent from "./OtherPageContent/OtherPageContent";
+import ComingSoon from "./HeroImage/ComingSoon";
 
 
 
@@ -26,6 +26,7 @@ const NewHomePage = () => {
         <div className={classes.main}>
             <NewAppBar />
             <HeroImage />
+            <ComingSoon />
             <OtherPageContent />
             <AppFooter />
         </div>

--- a/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupOne.js
+++ b/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupOne.js
@@ -46,13 +46,13 @@ const useStyles = makeStyles((theme) => ({
         [theme.breakpoints.down("sm")]: {
             textDecoration: "none !important",
             display: "block !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
             borderBottom: "none !important",
         },
     },
     typographyone: {
         [theme.breakpoints.down("sm")]: {
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     boxtwo: {
@@ -88,7 +88,7 @@ const PhoneMockupOne = () => {
                                         Local Travel <span className={classes.span}> Professionals</span>
                                     </Typography>
                                 </Box>
-                                <Typography variant="h5" sx={{mt: 4}}>
+                                <Typography variant="h5" sx={{mt: 4}} style={{ textAlign: "justify" }}>
                                     {'We connect you with local, knowledgeable travel experts from wherever you are looking to go and let them plan the perfect trip based on their personal experience and your occasion, time and preferences.'}
                                 </Typography>
 

--- a/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupThree.js
+++ b/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupThree.js
@@ -58,13 +58,13 @@ const useStyles = makeStyles((theme) => ({
         borderBottom: "3px solid #0FAACD",
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     typographyone: {
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     }
 }))
@@ -91,8 +91,8 @@ const PhoneMockupOne = () => {
                             <Typography className={classes.typographyone} variant="h4" sx={{ my: 5, }}>
                                 Everything in one <Typography color="primary.main" className={classes.typography} display="inline-block" variant='h4'>place</Typography>
                             </Typography>
-                            <Typography variant="h5" mb={4} gutterBottom>
-                                {'Our app allows you and your companions to see your complete itinerary, day by day, including maps, tickets, images and reviews as well as chat with your agent any time you have a question or  need to make a change.'}
+                            <Typography variant="h5" mb={4} gutterBottom style={{ textAlign: "justify" }}>
+                                Our app allows you and your companions to see your complete itinerary, day by day, including maps, tickets, images and reviews as well as chat with your agent any time you have a question or  need to make a change.
                             </Typography>
                             <Button variant="outlined" style={{
                                 padding: "10px 55px",

--- a/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupTwo.js
+++ b/src/pages/NewHomepageTravelPage/OtherPageContent/PhoneMockupTwo.js
@@ -27,13 +27,13 @@ const useStyles = makeStyles((theme) => ({
         borderBottom: "3px solid #0FAACD",
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     typographyone: {
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     boxtwo: {
@@ -69,8 +69,8 @@ const PhoneMockupTwo = () => {
                             <Box className={classes.boxtwo}><Typography className={classes.typographyone} variant="h4" >
                                 From plan till you arrive
                             </Typography><Typography className={classes.typographytwo} color="primary.main" display="inline-block" variant='h4'>home</Typography></Box>
-                            <Typography variant="h5">
-                                {'We are there every step of the way. Your agent will provide an itinerary for your feedback, make any needed changes now or at any point in your journey, book every aspect of your trip and be there for any questions till you arrive home.'}
+                            <Typography variant="h5" style={{ textAlign: "justify" }}>
+                                We are there every step of the way. Your agent will provide an itinerary for your feedback, make any needed changes now or at any point in your journey, book every aspect of your trip and be there for any questions till you arrive home.
                             </Typography>
 
                         </Box>

--- a/src/pages/NewHomepageTravelPage/OtherPageContent/PopularLocationsCategories.js
+++ b/src/pages/NewHomepageTravelPage/OtherPageContent/PopularLocationsCategories.js
@@ -105,12 +105,12 @@ const useStyles = makeStyles((theme) => ({
         }
     },
     typography: {
-        marginLeft: "20px !important",
+        marginLeft: "10px !important",
         borderBottom: "3px solid #0FAACD",
         [theme.breakpoints.down("sm")]: {
 
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     typography1: {
@@ -125,7 +125,7 @@ const useStyles = makeStyles((theme) => ({
         [theme.breakpoints.down("sm")]: {
 
             borderBottom: "none !important",
-            fontSize: "25px !important",
+            fontSize: "35px !important",
         }
     },
     maintypography1: {
@@ -138,7 +138,6 @@ const useStyles = makeStyles((theme) => ({
     boxone: {
         display: "flex",
         flexDirection: "row !important",
-        marginLeft: " 30% !important",
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
             fontSize: "20px !important",
@@ -148,7 +147,6 @@ const useStyles = makeStyles((theme) => ({
     boxtwo: {
         display: "flex",
         flexDirection: "row !important",
-        marginLeft: " 30% !important",
         [theme.breakpoints.down("sm")]: {
             borderBottom: "none !important",
             fontSize: "20px !important",
@@ -174,13 +172,16 @@ export default function PopularLocationCategories() {
     return (
         <Grid mb={5} pl={4} pr={4} pt={5}>
             <Fade bottom>
-                <Grid >
+                <Grid container
+                    spacing={0}
+                    direction="column"
+                    alignItems="center"
+                    justifyContent="center" >
                     <Grid item xs={12}>
                         <Box className={classes.boxone}>
                             <Typography className={classes.maintypography} variant="h4" align="center" component="h2" >
-                                We arrange the
+                                We arrange the<Typography variant='h4' display="inline-block" color="primary.main" className={classes.typography} >best</Typography>
                             </Typography>
-                            <Typography variant='h4' display="inline-block" color="primary.main" className={classes.typography} >  best</Typography>
                         </Box>
                         <Box className={classes.boxtwo}>
                             <Typography className={classes.maintypography1} variant="h6" align="center" component="h2" >
@@ -189,7 +190,7 @@ export default function PopularLocationCategories() {
 
                         </Box>
                     </Grid>
-                    <Grid >
+                    <Grid item xs={12} width={"100%"}>
                         <Box className={classes.item} width={"100%"} sx={{ mt: 8, display: 'flex', borderRadius: 50, }}>
                             {images.map((image) => (
                                 <ImageIconButton

--- a/src/pages/NewHomepageTravelPage/OtherPageContent/RatingsSlider.js
+++ b/src/pages/NewHomepageTravelPage/OtherPageContent/RatingsSlider.js
@@ -90,14 +90,14 @@ const useStyles = makeStyles((theme) => ({
     borderBottom: "3px solid #0FAACD",
     [theme.breakpoints.down("sm")]: {
       borderBottom: "none !important",
-      fontSize: "25px !important",
+      fontSize: "35px !important",
       marginLeft: "40px !important",
     },
   },
   typographythree: {
     [theme.breakpoints.down("sm")]: {
       marginLeft: "40px !important",
-      fontSize: "25px !important",
+      fontSize: "35px !important",
     },
   },
   typographyfour: {
@@ -285,6 +285,7 @@ const RatingsSlider = () => {
                               variant="h6"
                               component="h3"
                               marginTop={0}
+                              style={{ textAlign: "justify" }}
                             >
                               {newData.details}
                             </Typography>


### PR DESCRIPTION
Home Page (MOBILE VIEW)
1. “Travel Planning, Reinvented” spacing is too far apart, and subheading is poorly aligned (github)
3. Additionally, justify margins for the body text
PHONE MOCKUP SCREENSHOT SECTIONS
“Local Travel Professionals” - There needs to be a space between the title and the body text. Please justify margins for the body text. (github)
2. “From Plan til you arrive home” Justify the margins for the body text (github) “Everything in one place” —> Justify margins for the body text (github)
3. “We arrange the best”- fix spacing for the title, there are 2 spaces between THE and BEST. Please make body text size a bit smaller (github)
From Izanna:
1 quick note though, can you centre this title on desktop please?
2. Increase the header size in mobile view